### PR TITLE
Mention MERCURY_KEY in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,9 @@ DB_DATABASE=homestead
 DB_USERNAME=homestead
 DB_PASSWORD=secret
 
+# https://mercury.postlight.com/web-parser/
+MERCURY_KEY=
+
 BROADCAST_DRIVER=log
 CACHE_DRIVER=file
 SESSION_DRIVER=file

--- a/config/knowfox.php
+++ b/config/knowfox.php
@@ -10,6 +10,6 @@ return [
 
     'types' => [],
 
-    'mercury_key' => env('MERCURY_KEY', 'secret key for https://mercury.postlight.com/web-parser/'),
+    'mercury_key' => env('MERCURY_KEY', 'secret key'),
     'presentation_base_path' => env('PRESENTATION_BASE', base_path()),
 ];


### PR DESCRIPTION
On a fresh installation adding bookmarks leads to exceptions because of the usage of mercury.